### PR TITLE
Refactor segment velocity waveform shape metrics pipeline

### DIFF
--- a/src/pipelines/Segments_velocity_waveform_shape_metrics.py
+++ b/src/pipelines/Segments_velocity_waveform_shape_metrics.py
@@ -6,190 +6,315 @@ from .core.base import ProcessPipeline, ProcessResult, registerPipeline, with_at
 @registerPipeline(name="segment_waveform_shape_metrics")
 class ArterialSegExample(ProcessPipeline):
     """
-    Tutorial pipeline showing the full surface area of a pipeline:
+    Waveform-shape metrics on per-beat, per-branch, per-radius velocity waveforms.
 
-    - Subclass ProcessPipeline and implement `run(self, h5file) -> ProcessResult`.
-    - Return metrics (scalars, vectors, matrices, cubes) and optional artifacts.
-    - Attach HDF5 attributes to any metric via `with_attrs(data, attrs_dict)`.
-    - Add attributes to the pipeline group (`attrs`) or root file (`file_attrs`).
-    - No input data is required; this pipeline is purely illustrative.
+    Expected v_block layout:
+        v_block[:, beat_idx, branch_idx, radius_idx]
+    i.e. v_block shape: (n_t, n_beats, n_branches, n_radii)
+
+    Outputs
+    -------
+    A) Per-segment (flattened branch×radius):
+        *_segment : shape (n_beats, n_segments)
+        where n_segments = n_branches * n_radii and
+              seg_idx = branch_idx * n_radii + radius_idx   (branch-major)
+
+    B) Aggregated:
+        *_branch : shape (n_beats, n_branches)   (median over radii)
+        *_global : shape (n_beats,)              (mean over all branches & radii)
+
+    Metric definitions
+    ------------------
+    - Rectification: v <- max(v, 0) (NaNs preserved)
+    - tau_M1: first moment time / zeroth moment on rectified waveform
+        tau_M1 = M1/M0,  M0 = sum(v), M1 = sum(v * t_k), t_k = k * (Tbeat/n_t)
+    - tau_M1_over_T: (tau_M1 / Tbeat)
+    - RI (robust): RI = 1 - vmin/vmax with guards for vmax<=0 or all-NaN
+    - R_VTI_*: kept dataset name for compatibility, but uses PAPER convention:
+        RVTI = D1 / (D2 + eps)
+        D1 = sum(v[0:k]), D2 = sum(v[k:n_t]), k = ceil(n_t * ratio), ratio=0.5
     """
 
-    description = "Tutorial: metrics + artifacts + dataset attrs + file/pipeline attrs."
-    v_raw_input = "/Artery/VelocityPerBeat/Segments/VelocitySignalPerBeatPerSegment/value"
-    v_bandlimited_input = "/Artery/VelocityPerBeat/Segments/VelocitySignalPerBeatPerSegmentBandLimited/value"
-    T = "/Artery/VelocityPerBeat/beatPeriodSeconds/value"
-    
+    description = "Segment waveform shape metrics (tau, RI, RVTI) + branch/global aggregates."
 
+    v_raw_input = "/Artery/VelocityPerBeat/Segments/VelocitySignalPerBeatPerSegment/value"
+    v_bandlimited_input = (
+        "/Artery/VelocityPerBeat/Segments/VelocitySignalPerBeatPerSegmentBandLimited/value"
+    )
+    T_input = "/Artery/VelocityPerBeat/beatPeriodSeconds/value"
+
+    @staticmethod
+    def _rectify_keep_nan(x: np.ndarray) -> np.ndarray:
+        x = np.asarray(x, dtype=float)
+        return np.where(np.isfinite(x), np.maximum(x, 0.0), np.nan)
+
+    @staticmethod
+    def _safe_nanmean(x: np.ndarray) -> float:
+        if x.size == 0 or not np.any(np.isfinite(x)):
+            return 0.0
+        return float(np.nanmean(x))
+
+    @staticmethod
+    def _safe_nanmedian(x: np.ndarray) -> float:
+        if x.size == 0 or not np.any(np.isfinite(x)):
+            return 0.0
+        return float(np.nanmedian(x))
+
+    @staticmethod
+    def _metrics_from_waveform(
+        v: np.ndarray,
+        Tbeat: float,
+        ratio: float = 0.5,
+        eps: float = 1e-12,
+    ):
+        v = ArterialSegExample._rectify_keep_nan(v)
+
+        n = int(v.size)
+        if n <= 0:
+            return 0.0, 0.0, 0.0, 0.0
+
+        # tau_M1 and tau_M1/T (PER WAVEFORM ONLY)
+        if (not np.isfinite(Tbeat)) or Tbeat <= 0:
+            tau_M1 = 0.0
+            tau_M1_over_T = 0.0
+        else:
+            m0 = np.nansum(v)
+            if (not np.isfinite(m0)) or m0 <= 0:
+                tau_M1 = 0.0
+                tau_M1_over_T = 0.0
+            else:
+                dt = Tbeat / n
+                t = np.arange(n, dtype=float) * dt
+                m1 = np.nansum(v * t)
+                tau_M1 = (m1 / m0) if np.isfinite(m1) else 0.0
+                tau_M1_over_T = tau_M1 / Tbeat
+
+        # RI robust
+        if not np.any(np.isfinite(v)):
+            RI = 0.0
+        else:
+            vmax = np.nanmax(v)
+            if (not np.isfinite(vmax)) or vmax <= 0:
+                RI = 0.0
+            else:
+                vmin = np.nanmin(v)
+                RI = 1.0 - (vmin / vmax)
+                if not np.isfinite(RI):
+                    RI = 0.0
+                else:
+                    RI = float(np.clip(RI, 0.0, 1.0))
+
+        # RVTI (paper): D1/(D2+eps)
+        k = int(np.ceil(n * ratio))
+        k = max(0, min(n, k))
+        D1 = np.nansum(v[:k]) if k > 0 else 0.0
+        D2 = np.nansum(v[k:]) if k < n else 0.0
+        if not np.isfinite(D1):
+            D1 = 0.0
+        if not np.isfinite(D2):
+            D2 = 0.0
+        RVTI = float(D1 / (D2 + eps))
+
+        return float(tau_M1), float(tau_M1_over_T), float(RI), RVTI
+
+    def _compute_block(self, v_block: np.ndarray, T: np.ndarray, ratio: float):
+        if v_block.ndim != 4:
+            raise ValueError(f"Expected (n_t,n_beats,n_branches,n_radii), got {v_block.shape}")
+
+        n_t, n_beats, n_branches, n_radii = v_block.shape
+        n_segments = n_branches * n_radii
+
+        # Per-segment flattened (beat, segment)
+        tau_seg = np.zeros((n_beats, n_segments), dtype=float)
+        tauT_seg = np.zeros((n_beats, n_segments), dtype=float)
+        RI_seg = np.zeros((n_beats, n_segments), dtype=float)
+        RVTI_seg = np.zeros((n_beats, n_segments), dtype=float)
+
+        # Aggregated
+        tau_branch = np.zeros((n_beats, n_branches), dtype=float)
+        tauT_branch = np.zeros((n_beats, n_branches), dtype=float)
+        RI_branch = np.zeros((n_beats, n_branches), dtype=float)
+        RVTI_branch = np.zeros((n_beats, n_branches), dtype=float)
+
+        tau_global = np.zeros((n_beats,), dtype=float)
+        tauT_global = np.zeros((n_beats,), dtype=float)
+        RI_global = np.zeros((n_beats,), dtype=float)
+        RVTI_global = np.zeros((n_beats,), dtype=float)
+
+        for beat_idx in range(n_beats):
+            Tbeat = float(T[0][beat_idx])
+
+            # Global accumulators for this beat
+            tau_vals = []
+            tauT_vals = []
+            RI_vals = []
+            RVTI_vals = []
+
+            for branch_idx in range(n_branches):
+                # Branch accumulators across radii
+                tau_b = []
+                tauT_b = []
+                RI_b = []
+                RVTI_b = []
+
+                for radius_idx in range(n_radii):
+                    v = v_block[:, beat_idx, branch_idx, radius_idx]
+                    tM1, tM1T, ri, rvti = self._metrics_from_waveform(
+                        v=v, Tbeat=Tbeat, ratio=ratio, eps=1e-12
+                    )
+
+                    seg_idx = branch_idx * n_radii + radius_idx
+                    tau_seg[beat_idx, seg_idx] = tM1
+                    tauT_seg[beat_idx, seg_idx] = tM1T
+                    RI_seg[beat_idx, seg_idx] = ri
+                    RVTI_seg[beat_idx, seg_idx] = rvti
+
+                    tau_b.append(tM1)
+                    tauT_b.append(tM1T)
+                    RI_b.append(ri)
+                    RVTI_b.append(rvti)
+
+                    tau_vals.append(tM1)
+                    tauT_vals.append(tM1T)
+                    RI_vals.append(ri)
+                    RVTI_vals.append(rvti)
+
+                # Branch aggregates: MEDIAN over radii
+                tau_branch[beat_idx, branch_idx] = self._safe_nanmedian(np.asarray(tau_b))
+                tauT_branch[beat_idx, branch_idx] = self._safe_nanmedian(np.asarray(tauT_b))
+                RI_branch[beat_idx, branch_idx] = self._safe_nanmedian(np.asarray(RI_b))
+                RVTI_branch[beat_idx, branch_idx] = self._safe_nanmedian(np.asarray(RVTI_b))
+
+            # Global aggregates: MEAN over all branches & radii
+            tau_global[beat_idx] = self._safe_nanmean(np.asarray(tau_vals))
+            tauT_global[beat_idx] = self._safe_nanmean(np.asarray(tauT_vals))
+            RI_global[beat_idx] = self._safe_nanmean(np.asarray(RI_vals))
+            RVTI_global[beat_idx] = self._safe_nanmean(np.asarray(RVTI_vals))
+
+        return (
+            tau_seg, tauT_seg, RI_seg, RVTI_seg,
+            tau_branch, tauT_branch, RI_branch, RVTI_branch,
+            tau_global, tauT_global, RI_global, RVTI_global,
+            n_branches, n_radii
+        )
 
     def run(self, h5file) -> ProcessResult:
-
         v_raw = np.asarray(h5file[self.v_raw_input])
-        v_raw = np.maximum(v_raw, 0)
+        v_band = np.asarray(h5file[self.v_bandlimited_input])
+        T = np.asarray(h5file[self.T_input])
 
-        v_bandlimited = np.asarray(h5file[self.v_bandlimited_input])
-        v_bandlimited = np.maximum(v_bandlimited, 0)
+        v_raw = self._rectify_keep_nan(v_raw)
+        v_band = self._rectify_keep_nan(v_band)
 
-        T = np.asarray(h5file[self.T])
-
-        moment_0_segment = 0
-        moment_1_segment = 0
-
-        Tau_M1_bandlimited_segment = []
-        Tau_M1_over_T_bandlimited_segment = []
-        RI_bandlimited_segment = []
-        R_VTI_bandlimited_segment = []
-        
-        Tau_M1_raw_segment = []
-        Tau_M1_over_T_raw_segment = []
-        RI_raw_segment = []
-        R_VTI_raw_segment = []
-        
         ratio_systole_diastole_R_VTI = 0.5
 
-        for beat_idx in range(len(v_bandlimited[0, :, 0, 0])):
+        (
+            tau_seg_b, tauT_seg_b, RI_seg_b, RVTI_seg_b,
+            tau_br_b, tauT_br_b, RI_br_b, RVTI_br_b,
+            tau_gl_b, tauT_gl_b, RI_gl_b, RVTI_gl_b,
+            n_branches_b, n_radii_b
+        ) = self._compute_block(v_band, T, ratio_systole_diastole_R_VTI)
 
-            Tau_M1_bandlimited_branch = []
-            Tau_M1_over_T_bandlimited_branch = []
-            RI_bandlimited_branch = []
-            R_VTI_bandlimited_branch = []
-            
+        (
+            tau_seg_r, tauT_seg_r, RI_seg_r, RVTI_seg_r,
+            tau_br_r, tauT_br_r, RI_br_r, RVTI_br_r,
+            tau_gl_r, tauT_gl_r, RI_gl_r, RVTI_gl_r,
+            n_branches_r, n_radii_r
+        ) = self._compute_block(v_raw, T, ratio_systole_diastole_R_VTI)
 
-            for branch_idx in range(len(v_bandlimited[0, beat_idx, :, 0])):
+        # Consistency attributes (optional but useful)
+        seg_order_note = "seg_idx = branch_idx * n_radii + radius_idx (branch-major flattening)"
+        if n_radii_b != n_radii_r or n_branches_b != n_branches_r:
+            seg_order_note += " | WARNING: raw/bandlimited branch/radius dims differ."
 
-                v_bandlimited_average = np.nanmean(v_bandlimited[:, beat_idx, branch_idx, :], axis=1)
-                t = T[0][beat_idx] / len(v_bandlimited_average)
-
-                moment_0_segment += np.sum(v_bandlimited_average)
-                for time_idx in range(len(v_bandlimited_average)):
-                    moment_1_segment += v_bandlimited_average[time_idx] * time_idx * t
-
-                if moment_0_segment!=0:
-                    TM1=moment_1_segment/moment_0_segment
-                    Tau_M1_bandlimited_branch.append(TM1)
-                    Tau_M1_over_T_bandlimited_branch.append(TM1/T[0][beat_idx])
-                else:
-                    Tau_M1_bandlimited_branch.append(0)
-                    Tau_M1_over_T_bandlimited_branch.append(0)
-
-                
-                v_bandlimited_max=np.max(v_bandlimited_average)
-                v_bandlimited_min=np.min(v_bandlimited_average)
-                
-                RI_bandlimited_branch_idx = 1 - (v_bandlimited_min / v_bandlimited_max)
-                RI_bandlimited_branch.append(RI_bandlimited_branch_idx)
-
-                epsilon = 10 ** (-12)
-                D1_bandlimited = np.sum(v_bandlimited_average[: int(np.ceil(len(v_bandlimited_average) * ratio_systole_diastole_R_VTI))])
-                D2_bandlimited = np.sum(v_bandlimited_average[int(np.ceil(len(v_bandlimited_average) * ratio_systole_diastole_R_VTI)) :])
-                R_VTI_bandlimited_branch.append(D2_bandlimited / (D1_bandlimited + epsilon))
-
-            Tau_M1_bandlimited_segment.append(Tau_M1_bandlimited_branch)
-            Tau_M1_over_T_bandlimited_segment.append(Tau_M1_over_T_bandlimited_branch)
-            RI_bandlimited_segment.append(RI_bandlimited_branch)
-            R_VTI_bandlimited_segment.append(R_VTI_bandlimited_branch)
-
-
-        
-
-        for beat_idx in range(len(v_raw[0, :, 0, 0])):
-
-            Tau_M1_raw_branch = []
-            Tau_M1_over_T_raw_branch = []
-            RI_raw_branch = []
-            R_VTI_raw_branch = []
-            
-
-            for branch_idx in range(len(v_raw[0, beat_idx, :, 0])):
-
-                v_raw_average = np.nanmean(v_raw[:, beat_idx, branch_idx, :], axis=1)
-                t = T[0][beat_idx] / len(v_raw_average)
-
-                moment_0_segment += np.sum(v_raw_average)
-                for time_idx in range(len(v_raw_average)):
-                    moment_1_segment += v_raw_average[time_idx] * time_idx * t
-
-                if moment_0_segment!=0:
-                    TM1=moment_1_segment/moment_0_segment
-                    Tau_M1_raw_branch.append(TM1)
-                    Tau_M1_over_T_raw_branch.append(TM1/T[0][beat_idx])
-                else:
-                    Tau_M1_raw_branch.append(0)
-                    Tau_M1_over_T_raw_branch.append(0)
-
-                
-                v_raw_max=np.max(v_raw_average)
-                v_raw_min=np.min(v_raw_average)
-                
-                RI_raw_branch_idx = 1 - (v_raw_min / v_raw_max)
-                RI_raw_branch.append(RI_raw_branch_idx)
-
-                epsilon = 10 ** (-12)
-                D1_raw = np.sum(v_raw_average[: int(np.ceil(len(v_raw_average) * ratio_systole_diastole_R_VTI))])
-                D2_raw = np.sum(v_raw_average[int(np.ceil(len(v_raw_average) * ratio_systole_diastole_R_VTI)) :])
-                R_VTI_raw_branch.append(D2_raw / (D1_raw + epsilon))
-
-            Tau_M1_raw_segment.append(Tau_M1_raw_branch)
-            Tau_M1_over_T_raw_segment.append(Tau_M1_over_T_raw_branch)
-            RI_raw_segment.append(RI_raw_branch)
-            R_VTI_raw_segment.append(R_VTI_raw_branch)
-
-        
-
-        # Metrics are the main numerical outputs; each key becomes a dataset under /pipelines/<name>/metrics.
         metrics = {
+            # --- Existing datasets (unchanged names/shapes) ---
             "tau_M1_bandlimited_segment": with_attrs(
-                np.asarray(Tau_M1_bandlimited_segment),
-                {
-                    "unit": [""],
-                },
-            ),
-            "R_VTI_bandlimited_segment": with_attrs(
-                np.asarray( R_VTI_bandlimited_segment),
-                {
-                    "unit": [""],
-                },
-            ),
-            "RI_bandlimited_segment": with_attrs(
-                np.asarray(RI_bandlimited_segment),
-                {
-                    "unit": [""],
-                },
+                tau_seg_b,
+                {"unit": ["s"], "definition": ["tau_M1 = M1/M0 on rectified waveform"], "segment_indexing": [seg_order_note]},
             ),
             "tau_M1_over_T_bandlimited_segment": with_attrs(
-                np.asarray(Tau_M1_over_T_bandlimited_segment),
-                {
-                    "unit": [""],
-                },
+                tauT_seg_b,
+                {"unit": [""], "definition": ["tau_M1_over_T = (M1/M0)/T"], "segment_indexing": [seg_order_note]},
             ),
-            
+            "RI_bandlimited_segment": with_attrs(
+                RI_seg_b,
+                {"unit": [""], "definition": ["RI = 1 - vmin/vmax (robust, rectified)"], "segment_indexing": [seg_order_note]},
+            ),
+            "R_VTI_bandlimited_segment": with_attrs(
+                RVTI_seg_b,
+                {"unit": [""], "definition": ["paper RVTI = D1/(D2+eps)"], "segment_indexing": [seg_order_note]},
+            ),
+
             "tau_M1_raw_segment": with_attrs(
-                np.asarray(Tau_M1_raw_segment),
-                {
-                    "unit": [""],
-                },
-            ),
-            "R_VTI_raw_segment": with_attrs(
-                np.asarray( R_VTI_raw_segment),
-                {
-                    "unit": [""],
-                },
-            ),
-            "RI_raw_segment": with_attrs(
-                np.asarray(RI_raw_segment),
-                {
-                    "unit": [""],
-                },
+                tau_seg_r,
+                {"unit": ["s"], "definition": ["tau_M1 = M1/M0 on rectified waveform"], "segment_indexing": [seg_order_note]},
             ),
             "tau_M1_over_T_raw_segment": with_attrs(
-                np.asarray(Tau_M1_over_T_raw_segment),
-                {
-                    "unit": [""],
-                },
+                tauT_seg_r,
+                {"unit": [""], "definition": ["tau_M1_over_T = (M1/M0)/T"], "segment_indexing": [seg_order_note]},
             ),
-            "ratio_systole_diastole_R_VTI": np.asarray(ratio_systole_diastole_R_VTI),
-        }
+            "RI_raw_segment": with_attrs(
+                RI_seg_r,
+                {"unit": [""], "definition": ["RI = 1 - vmin/vmax (robust, rectified)"], "segment_indexing": [seg_order_note]},
+            ),
+            "R_VTI_raw_segment": with_attrs(
+                RVTI_seg_r,
+                {"unit": [""], "definition": ["paper RVTI = D1/(D2+eps)"], "segment_indexing": [seg_order_note]},
+            ),
 
-        # Artifacts can store non-metric outputs (strings, paths, etc.).
+            "ratio_systole_diastole_R_VTI": np.asarray(ratio_systole_diastole_R_VTI, dtype=float),
+
+            # --- New aggregated outputs ---
+            "tau_M1_bandlimited_branch": with_attrs(
+                tau_br_b, {"unit": ["s"], "definition": ["median over radii: tau_M1 per branch"]}
+            ),
+            "tau_M1_over_T_bandlimited_branch": with_attrs(
+                tauT_br_b, {"unit": [""], "definition": ["median over radii: tau_M1/T per branch"]}
+            ),
+            "RI_bandlimited_branch": with_attrs(
+                RI_br_b, {"unit": [""], "definition": ["median over radii: RI per branch"]}
+            ),
+            "R_VTI_bandlimited_branch": with_attrs(
+                RVTI_br_b, {"unit": [""], "definition": ["median over radii: paper RVTI per branch"]}
+            ),
+            "tau_M1_bandlimited_global": with_attrs(
+                tau_gl_b, {"unit": ["s"], "definition": ["mean over branches & radii: tau_M1 global"]}
+            ),
+            "tau_M1_over_T_bandlimited_global": with_attrs(
+                tauT_gl_b, {"unit": [""], "definition": ["mean over branches & radii: tau_M1/T global"]}
+            ),
+            "RI_bandlimited_global": with_attrs(
+                RI_gl_b, {"unit": [""], "definition": ["mean over branches & radii: RI global"]}
+            ),
+            "R_VTI_bandlimited_global": with_attrs(
+                RVTI_gl_b, {"unit": [""], "definition": ["mean over branches & radii: paper RVTI global"]}
+            ),
+
+            "tau_M1_raw_branch": with_attrs(
+                tau_br_r, {"unit": ["s"], "definition": ["median over radii: tau_M1 per branch"]}
+            ),
+            "tau_M1_over_T_raw_branch": with_attrs(
+                tauT_br_r, {"unit": [""], "definition": ["median over radii: tau_M1/T per branch"]}
+            ),
+            "RI_raw_branch": with_attrs(
+                RI_br_r, {"unit": [""], "definition": ["median over radii: RI per branch"]}
+            ),
+            "R_VTI_raw_branch": with_attrs(
+                RVTI_br_r, {"unit": [""], "definition": ["median over radii: paper RVTI per branch"]}
+            ),
+            "tau_M1_raw_global": with_attrs(
+                tau_gl_r, {"unit": ["s"], "definition": ["mean over branches & radii: tau_M1 global"]}
+            ),
+            "tau_M1_over_T_raw_global": with_attrs(
+                tauT_gl_r, {"unit": [""], "definition": ["mean over branches & radii: tau_M1/T global"]}
+            ),
+            "RI_raw_global": with_attrs(
+                RI_gl_r, {"unit": [""], "definition": ["mean over branches & radii: RI global"]}
+            ),
+            "R_VTI_raw_global": with_attrs(
+                RVTI_gl_r, {"unit": [""], "definition": ["mean over branches & radii: paper RVTI global"]}
+            ),
+        }
 
         return ProcessResult(metrics=metrics)


### PR DESCRIPTION
Refactor pipeline to compute waveform shape metrics including tau_M1, RI, and RVTI. Update input handling and add new aggregated outputs for branches and global metrics.

Summary of changes:

* Rewrote segment_waveform_shape_metrics pipeline for correctness, robustness, and paper-consistent definitions, while preserving existing dataset names and segment array shapes.

1. Fix tau accumulator bug (core correctness)

* Before: moment_0_segment and moment_1_segment were accumulated with "+=" across all beats/segments and carried from bandlimited into raw.
* Now: tau_M1 and tau_M1/T are computed independently for each waveform v(t) for each (beat, branch, radius):

  * M0 = sum(v)
  * M1 = sum(v * t_k), where t_k = k * (Tbeat / n)
  * tau_M1 = M1 / M0, tau_M1_over_T = tau_M1 / Tbeat

2. Correct segment indexing: segments = branches x radii

* Expected input layout: v_block[:, beat_idx, branch_idx, radius_idx]
* Kept existing "*_segment" outputs by flattening (branch_idx, radius_idx) into:

  * seg_idx = branch_idx * n_radii + radius_idx (branch-major)
* Result: per-segment datasets keep shape (n_beats, n_segments) with n_segments = n_branches * n_radii.

3. Make RI robust (no div-by-zero / NaN blowups)

* If all-NaN waveform or vmax <= 0, set RI = 0.
* Else RI = 1 - vmin/vmax, with NaN checks and clamp to [0,1] for rectified signals.

4. Align RVTI to paper definition (keep dataset name)

* Before: stored ratio was D2/(D1+eps) (late/early), inverse of the paper.
* Now: compute paper RVTI = D1/(D2+eps) (early/late), with split k = ceil(n * 0.5).
* Kept dataset key name "R_VTI_*_segment" for compatibility, but definition now matches the paper (and is documented in attrs).

5. Add aggregates (new outputs)

* Branch aggregates: per beat and branch, median over radii (robust). Shape (n_beats, n_branches).
* Global aggregates: per beat, mean over all branches and radii. Shape (n_beats,).
* Added raw and bandlimited versions for tau_M1, tau_M1_over_T, RI, and R_VTI.

6. Preserve existing core dataset names and shapes

* Unchanged names/shapes for:

  * tau_M1_{raw,bandlimited}_segment
  * tau_M1_over_T_{raw,bandlimited}_segment
  * RI_{raw,bandlimited}_segment
  * R_VTI_{raw,bandlimited}_segment
  * ratio_systole_diastole_R_VTI
* Added/updated HDF5 attrs (unit/definition and segment indexing note).

Behavior changes

* tau_M1_* and tau_M1_over_T_* values change (now correct per waveform).
* R_VTI_* values change because they now represent paper RVTI (D1/(D2+eps)) instead of the previous inverse.