### PR TITLE
Add watershed peak width metrics and

### DIFF
--- a/src/pipelines/arterial_waveform_shape_metrics.py
+++ b/src/pipelines/arterial_waveform_shape_metrics.py
@@ -38,6 +38,9 @@ class ArterialSegExample(ProcessPipeline):
     H_MAX = 10
     H_PHASE_RESIDUAL = 10
 
+    ratio_W50 = 0.50
+    ratio_W75 = 0.75
+
     @staticmethod
     def _rectify_keep_nan(x: np.ndarray) -> np.ndarray:
         x = np.asarray(x, dtype=float)
@@ -101,7 +104,7 @@ class ArterialSegExample(ProcessPipeline):
     def _quantile_time_over_T(self, v: np.ndarray, Tbeat: float, q: float) -> float:
         """
         v: rectified 1D waveform (NaNs allowed)
-        Returns t_q / Tbeat where C(t_q) >= q, with C = cumsum(v)/sum(v).
+        Returns t_q / Tbeat where d(t_q) >= q, with d(t)=cumsum(v)/sum(v) and q in [0,1].
         """
         if (not np.isfinite(Tbeat)) or Tbeat <= 0:
             return np.nan
@@ -109,18 +112,77 @@ class ArterialSegExample(ProcessPipeline):
         if v.size == 0 or not np.any(np.isfinite(v)):
             return np.nan
 
-        vv = np.where(np.isfinite(v), v, np.nan)
-        m0 = float(np.nansum(vv))
+        vv = np.where(np.isfinite(v), v, 0.0)
+        m0 = float(np.sum(vv))
         if m0 <= 0:
             return np.nan
 
-        c = np.nancumsum(vv) / m0
-        idx = int(np.searchsorted(c, q, side="left"))
-        idx = max(0, min(v.size - 1, idx))
+        q = float(np.clip(q, 0.0, 1.0))
+        d_full = np.concatenate(([0.0], np.cumsum(vv) / m0))
+        tau_full = np.linspace(0.0, 1.0, v.size + 1)
+
+        return float(np.interp(q, d_full, tau_full))
+
+
+    def _peak_width_over_T(self, v: np.ndarray, alpha: float) -> float:
+        """
+        Beat-normalized near-peak width:
+          W_alpha/T = (1/T) * |{t in [0,T] : v(t) >= alpha * v_max}|
+
+        On a uniformly sampled grid this is the fraction of valid samples above the threshold.
+        """
+        if v.size == 0 or not np.any(np.isfinite(v)):
+            return np.nan
+        if (not np.isfinite(alpha)) or alpha <= 0 or alpha >= 1:
+            return np.nan
+
+        vv = np.asarray(v, dtype=float)
+        vmax = float(np.nanmax(vv))
+        if (not np.isfinite(vmax)) or vmax <= 0:
+            return np.nan
+
+        mask = np.isfinite(vv)
+        if not np.any(mask):
+            return np.nan
+
+        above = mask & (vv >= alpha * vmax)
+        return float(np.sum(above) / vv.size)
+
+    def _n_h_over_T(self, v: np.ndarray, Tbeat: float, m0: float) -> float:
+        """
+        Beat-normalized entropic effective support:
+          p(t) = v(t)/M0
+          N_H/T = exp( - integral_0^T p(t) log(T p(t)) dt )
+        with the convention 0*log(0)=0.
+        """
+        if (
+            v.size == 0
+            or (not np.any(np.isfinite(v)))
+            or (not np.isfinite(Tbeat))
+            or Tbeat <= 0
+        ):
+            return np.nan
+        if (not np.isfinite(m0)) or m0 <= 0:
+            return np.nan
 
         dt = Tbeat / v.size
-        t_q = idx * dt
-        return float(t_q / Tbeat)
+        M0 = m0 * dt
+        if (not np.isfinite(M0)) or M0 <= 0:
+            return np.nan
+
+        p = np.where(np.isfinite(v), v, 0.0) / M0
+        Tp = Tbeat * p
+
+        integrand = np.zeros_like(Tp, dtype=float)
+        positive = Tp > 0
+        integrand[positive] = p[positive] * np.log(Tp[positive])
+
+        entropy_like = -float(np.sum(integrand) * dt)
+        if not np.isfinite(entropy_like):
+            return np.nan
+
+        n_h_over_t = float(np.exp(entropy_like))
+        return n_h_over_t if np.isfinite(n_h_over_t) else np.nan
 
     def _spectral_ratios(self, v: np.ndarray, Tbeat: float) -> tuple[float, float]:
         """
@@ -381,7 +443,11 @@ class ArterialSegExample(ProcessPipeline):
             return np.nan
 
         dt = Tbeat / v.size
-        p = np.where(np.isfinite(v), v, 0.0) / (m0 + self.eps)
+        M0 = m0 * dt
+        if (not np.isfinite(M0)) or M0 <= 0:
+            return np.nan
+
+        p = np.where(np.isfinite(v), v, 0.0) / M0
 
         int_p2 = float(np.sum(p * p) * dt)
         if not np.isfinite(int_p2) or int_p2 <= 0:
@@ -516,8 +582,9 @@ class ArterialSegExample(ProcessPipeline):
         delta_t_over_T: float,
     ) -> float:
         """
-        S_decay = ((v_min - v_max) T) / (Delta_t * v_mean)
-                = (v_min - v_max) / ( (Delta_t/T) * v_mean )
+        S_decay = ((v_max - v_min) T) / (Delta_t * v_mean)
+                = (v_max - v_min) / ( (Delta_t/T) * v_mean )
+                = PI / (Delta_t/T)
         """
         if not np.isfinite(vmin) or not np.isfinite(vmax):
             return np.nan
@@ -526,7 +593,7 @@ class ArterialSegExample(ProcessPipeline):
         if (not np.isfinite(delta_t_over_T)) or delta_t_over_T <= 0:
             return np.nan
 
-        return float((vmin - vmax) / ((delta_t_over_T + self.eps) * (meanv + self.eps)))
+        return float((vmax - vmin) / ((delta_t_over_T + self.eps) * (meanv + self.eps)))
 
     def _r_sd(self, v: np.ndarray) -> float:
         if v.size == 0 or not np.any(np.isfinite(v)):
@@ -581,10 +648,10 @@ class ArterialSegExample(ProcessPipeline):
             return np.nan
         if (not np.isfinite(m0)) or m0 <= 0:
             return np.nan
-        d = np.nancumsum(np.where(np.isfinite(v), v, 0.0))
-        d_star = d / (m0 + self.eps)
-        d0_star = t / Tbeat
-        return float(np.nansum(d_star - d0_star))
+        vv = np.where(np.isfinite(v), v, 0.0)
+        d_full = np.concatenate(([0.0], np.cumsum(vv) / m0))
+        tau_full = np.linspace(0.0, 1.0, v.size + 1)
+        return float(np.trapz(d_full - tau_full, tau_full))
 
     def _normalized_cumulative_displacement_samples(
         self, v: np.ndarray, Tbeat: float, m0: float
@@ -611,13 +678,12 @@ class ArterialSegExample(ProcessPipeline):
         if (not np.isfinite(m0)) or m0 <= 0:
             return out
 
-        D = np.nancumsum(np.where(np.isfinite(v), v, 0.0))
-        d = D / (m0 + self.eps)
+        vv = np.where(np.isfinite(v), v, 0.0)
+        d_full = np.concatenate(([0.0], np.cumsum(vv) / m0))
+        tau_full = np.linspace(0.0, 1.0, v.size + 1)
 
         def sample_at_ratio(r: float) -> float:
-            idx = int(np.floor(r * (v.size - 1)))
-            idx = max(0, min(v.size - 1, idx))
-            return float(d[idx])
+            return float(np.interp(r, tau_full, d_full))
 
         out["d10"] = sample_at_ratio(0.10)
         out["d25"] = sample_at_ratio(0.25)
@@ -701,12 +767,15 @@ class ArterialSegExample(ProcessPipeline):
 
         vv = np.where(np.isfinite(v), v, 0.0)
         dt = Tbeat / v.size
+        M0 = m0 * dt
+        if (not np.isfinite(M0)) or M0 <= 0:
+            return np.nan, np.nan
 
         dvdt = np.gradient(vv, dt)
         d2vdt2 = np.gradient(dvdt, dt)
 
-        E_slope = float((Tbeat**2) * np.sum(dvdt**2) * dt / ((m0 + self.eps) ** 2))
-        E_curv = float((Tbeat**4) * np.sum(d2vdt2**2) * dt / ((m0 + self.eps) ** 2))
+        E_slope = float((Tbeat**2) * np.sum(dvdt**2) * dt / ((M0 + self.eps) ** 2))
+        E_curv = float((Tbeat**4) * np.sum(d2vdt2**2) * dt / ((M0 + self.eps) ** 2))
 
         return E_slope, E_curv
 
@@ -722,20 +791,23 @@ class ArterialSegExample(ProcessPipeline):
             return {}
 
         vv = np.where(np.isfinite(v), v, np.nan)
-        m0 = float(np.nansum(vv))
-        if m0 <= 0:
+        m0_sum = float(np.nansum(vv))
+        if m0_sum <= 0:
             return {}
 
         tau = np.linspace(0.0, 1.0, n, endpoint=False)
         dt = Tbeat / n
         t = np.arange(n, dtype=float) * dt
+        m0 = float(m0_sum * dt)
 
         vmax = float(np.nanmax(vv))
         vmin = float(np.nanmin(vv))
         vmean = float(self._safe_nanmean(vv))
 
-        # Cumulative
-        cumulative = np.nancumsum(vv) / (m0 + self.eps)
+        # Cumulative displacement geometry sampled on normalized phase
+        d_full = np.concatenate(([0.0], np.cumsum(np.where(np.isfinite(vv), vv, 0.0)) / m0_sum))
+        tau_full = np.linspace(0.0, 1.0, n + 1)
+        cumulative = np.interp(tau, tau_full, d_full)
         d_star = np.asarray(cumulative, dtype=float)
         d0_star = np.asarray(tau, dtype=float)
         delta_dti_curve = d_star - d0_star
@@ -769,7 +841,7 @@ class ArterialSegExample(ProcessPipeline):
         dvdt = np.gradient(np.where(np.isfinite(vv), vv, 0.0), dt)
         d2vdt2 = np.gradient(dvdt, dt)
 
-        d_samples = self._normalized_cumulative_displacement_samples(vv, Tbeat, m0)
+        d_samples = self._normalized_cumulative_displacement_samples(vv, Tbeat, m0_sum)
 
         metrics = self._compute_metrics_1d(vv, Tbeat)
 
@@ -872,6 +944,9 @@ class ArterialSegExample(ProcessPipeline):
         sigma_t = np.sqrt(m2 / m0 + self.eps)
         sigma_t_over_T = sigma_t / Tbeat
 
+        W50_over_T = self._peak_width_over_T(vv, self.ratio_W50)
+        W75_over_T = self._peak_width_over_T(vv, self.ratio_W75)
+
         t10_over_T = self._quantile_time_over_T(vv, Tbeat, 0.10)
         t25_over_T = self._quantile_time_over_T(vv, Tbeat, 0.25)
         t50_over_T = self._quantile_time_over_T(vv, Tbeat, 0.50)
@@ -900,6 +975,7 @@ class ArterialSegExample(ProcessPipeline):
 
         mu_h, sigma_h = self._spectral_centroid_spread(V)
         N_eff_over_T = self._n_eff_over_T(vv, Tbeat, m0)
+        N_H_over_T = self._n_h_over_T(vv, Tbeat, m0)
 
         t_max_over_T, t_min_over_T, idx_peak, idx_min = self._peak_trough_times(vv)
         (
@@ -952,6 +1028,8 @@ class ArterialSegExample(ProcessPipeline):
             "SF_VTI": float(SF_VTI),
             "sigma_t_over_T": float(sigma_t_over_T),
             "sigma_t": float(sigma_t),
+            "W50_over_T": float(W50_over_T) if np.isfinite(W50_over_T) else np.nan,
+            "W75_over_T": float(W75_over_T) if np.isfinite(W75_over_T) else np.nan,
             "t10_over_T": float(t10_over_T),
             "t25_over_T": float(t25_over_T),
             "t50_over_T": float(t50_over_T),
@@ -1002,6 +1080,7 @@ class ArterialSegExample(ProcessPipeline):
             "N_eff_over_T": float(N_eff_over_T)
             if np.isfinite(N_eff_over_T)
             else np.nan,
+            "N_H_over_T": float(N_H_over_T) if np.isfinite(N_H_over_T) else np.nan,
             "phase_locking_residual": float(phase_locking_residual)
             if np.isfinite(phase_locking_residual)
             else np.nan,
@@ -1032,6 +1111,8 @@ class ArterialSegExample(ProcessPipeline):
             ["SF_VTI", "VTI_0_T3/VTI_0_T", ""],
             ["sigma_t_over_T", "sigma/T", ""],
             ["sigma_t", "sqrt(tau_M2-tau_M1**2)", "seconds"],
+            ["W50_over_T", "W_{50}/T", ""],
+            ["W75_over_T", "W_{75}/T", ""],
             ["t10_over_T", "t10/T", ""],
             ["t25_over_T", "t25/T", ""],
             ["t50_over_T", "t50/T", ""],
@@ -1051,13 +1132,13 @@ class ArterialSegExample(ProcessPipeline):
             ["slope_fall_normalized", "T*|min(dv/dt)|/V_mean", ""],
             ["t_up_over_T", "t_up/T", ""],
             ["t_down_over_T", "t_down/T", ""],
-            ["S_decay", "((V_min-V_max)T)/(Delta_t*V_mean)", ""],
+            ["S_decay", "((V_max-V_min)T)/(Delta_t*V_mean)", ""],
             [
                 "R_SD",
                 "V_max/(mean(V(t in [ratio_vend_start*T,ratio_vend_end*T]))+eps)",
                 "",
             ],
-            ["Delta_DTI", "int_0^1(d*(tau)-d0*(tau))dtau", ""],
+            ["Delta_DTI", "int_0^1(d*(tau)-tau)dtau", ""],
             ["gamma_t", "sum(w(t)*((t-mu)/sigma)^3)/sum(w(t))", ""],
             ["tauH", "sum(wn*(1/omega_n)*sqrt(1/|Xn|**2-1))/sum(wn)", "seconds"],
             ["crest_factor", "V_max/V_RMS", ""],
@@ -1066,6 +1147,7 @@ class ArterialSegExample(ProcessPipeline):
             ["mu_h", "sum_n n*|Vn|/sum_n |Vn|", ""],
             ["sigma_h", "sqrt(sum_n (n-mu_h)^2*|Vn|/sum_n |Vn|)", ""],
             ["N_eff_over_T", "N_eff/T", ""],
+            ["N_H_over_T", "N_H/T", ""],
             [
                 "phase_locking_residual",
                 "sum_n w_n*wrap(phi_n-n*phi_1)^2/sum_n w_n",
@@ -1180,6 +1262,8 @@ class ArterialSegExample(ProcessPipeline):
             "SF_VTI": r"$\frac{VTI_{0\rightarrow T/3}}{VTI_{0\rightarrow T}}$",
             "sigma_t": r"$\sigma_t=\sqrt{\frac{\sum_t v(t)(t-\mu_t)^2}{\sum_t v(t)}}$",
             "sigma_t_over_T": r"$\frac{\sigma_t}{T}$",
+            "W50_over_T": r"$\frac{W_{50}}{T}=\frac{1}{T}\left|\{t\in[0,T]:v(t)\geq 0.5\,v_{\max}\}\right|$",
+            "W75_over_T": r"$\frac{W_{75}}{T}=\frac{1}{T}\left|\{t\in[0,T]:v(t)\geq 0.75\,v_{\max}\}\right|$",
             "t10_over_T": r"$\frac{t_{10}}{T}$",
             "t25_over_T": r"$\frac{t_{25}}{T}$",
             "t50_over_T": r"$\frac{t_{50}}{T}$",
@@ -1199,9 +1283,9 @@ class ArterialSegExample(ProcessPipeline):
             "slope_fall_normalized": r"$\frac{T}{\bar v}\left|\min_t \frac{dv}{dt}\right|$",
             "t_up_over_T": r"$\frac{t_{\mathrm{up}}}{T}$",
             "t_down_over_T": r"$\frac{t_{\mathrm{down}}}{T}$",
-            "S_decay": r"$\frac{(v_{\min}-v_{\max})\,T}{\Delta t\,\bar v}$",
+            "S_decay": r"$\frac{(v_{\max}-v_{\min})\,T}{\Delta t\,\bar v}=\mathrm{PI}\,\frac{T}{\Delta t}$",
             "R_SD": r"$\frac{v_{\max}}{\mathrm{mean}_{t\in[\alpha T,\beta T]} v(t)+\epsilon}$",
-            "Delta_DTI": r"$\int_0^1 \left[d^*(\tau)-d_0^*(\tau)\right]d\tau$",
+            "Delta_DTI": r"$\int_0^1 \left[d^*(\tau)-\tau\right]d\tau$",
             "gamma_t": r"$\frac{1}{M_0}\sum_t v(t)\left(\frac{t-\mu_t}{\sigma_t}\right)^3$",
             "tauH": r"$\tau_H=\frac{\sum_n |V_n|\frac{1}{\omega_n}\sqrt{\frac{1}{|X_n|^2}-1}}{\sum_n |V_n|}$",
             "crest_factor": r"$\frac{v_{\max}}{v_{\mathrm{RMS}}}$",
@@ -1209,7 +1293,8 @@ class ArterialSegExample(ProcessPipeline):
             "delta_phi2": r"$\mathrm{wrap}(\phi_2-2\phi_1)$",
             "mu_h": r"$\mu_h=\sum_{n=1}^{N} n\,w_n,\quad w_n=\frac{|V_n|}{\sum_{k=1}^{N}|V_k|}$",
             "sigma_h": r"$\sigma_h=\sqrt{\sum_{n=1}^{N}(n-\mu_h)^2 w_n}$",
-            "N_eff_over_T": r"$\frac{N_{\mathrm{eff}}}{T}$",
+            "N_eff_over_T": r"$\frac{N_{\mathrm{eff}}}{T}=\frac{1}{T\int_0^T p(t)^2\,dt}$",
+            "N_H_over_T": r"$\frac{N_H}{T}=\exp\!\left(-\int_0^T p(t)\ln(Tp(t))\,dt\right)$",
             "phase_locking_residual": r"$E_{\phi}=\frac{\sum_{n=2}^{N} w_n\,\mathrm{wrap}(\phi_n-n\phi_1)^2}{\sum_{n=2}^{N} w_n+\epsilon}$",
             "E_recon_H_MAX": r"$E_{\mathrm{recon},H_{\max}}=\frac{\int_0^T (v(t)-v_{0:H_{\max}}(t))^2\,dt}{\int_0^T v(t)^2\,dt+\epsilon}$",
             "Q_t_skew": r"$Q_{t,\mathrm{skew}}=\frac{(t_{90}-t_{50})-(t_{50}-t_{10})}{t_{90}-t_{10}+\epsilon}$",
@@ -1296,6 +1381,12 @@ class ArterialSegExample(ProcessPipeline):
                 self.ratio_vend_end, dtype=float
             )
             metrics["by_segment/params/eps"] = np.asarray(self.eps, dtype=float)
+            metrics["by_segment/params/ratio_W50"] = np.asarray(
+                self.ratio_W50, dtype=float
+            )
+            metrics["by_segment/params/ratio_W75"] = np.asarray(
+                self.ratio_W75, dtype=float
+            )
             metrics["by_segment/params/H_LOW_MAX"] = np.asarray(
                 self.H_LOW_MAX, dtype=int
             )
@@ -1353,6 +1444,12 @@ class ArterialSegExample(ProcessPipeline):
                 self.ratio_vend_end, dtype=float
             )
             metrics["global/params/eps"] = np.asarray(self.eps, dtype=float)
+            metrics["global/params/ratio_W50"] = np.asarray(
+                self.ratio_W50, dtype=float
+            )
+            metrics["global/params/ratio_W75"] = np.asarray(
+                self.ratio_W75, dtype=float
+            )
             metrics["global/params/H_LOW_MAX"] = np.asarray(self.H_LOW_MAX, dtype=int)
             metrics["global/params/H_HIGH_MIN"] = np.asarray(self.H_HIGH_MIN, dtype=int)
             metrics["global/params/H_HIGH_MAX"] = np.asarray(self.H_HIGH_MAX, dtype=int)


### PR DESCRIPTION
Added ratio_W50 and ratio_W75 parameters for peak width calculations. Updated related methods to utilize these new ratios.

added:

W50_over_T

W75_over_T

N_H_over_T

corrected to match the paper:

fixed S_decay sign 

fixed Delta_DTI discretization so it approximates

instead of an unnormalized sum

fixed N_eff_over_T, N_H_over_T, E_slope, and E_curv so they use the integral M0, not just the raw sample sum

improved cumulative-displacement sampling and quantile timing with interpolation, so metrics like d50, t50_over_T, and Delta_DTI are consistent with the manuscript definitions

added exported params for the new crest-width thresholds:

ratio_W50 = 0.50

ratio_W75 = 0.75

added definitions and LaTeX formulas for the new metrics in the metadata

So the main newly available outputs are:

W50_over_T

W75_over_T

N_H_over_T

And the main hidden implementation bugs now fixed are:

S_decay

Delta_DTI

N_eff_over_T

E_slope

E_curv