### PR TITLE
Quickfix: topological metrics

### DIFF
--- a/src/pipelines/topological_metrics.py
+++ b/src/pipelines/topological_metrics.py
@@ -11,14 +11,27 @@ from .core.base import ProcessResult, registerPipeline, with_attrs
 from .waveform_shape_metrics import ArterialSegExample
 
 REGION_NAMES = (
-    "top_left",
-    "top_right",
-    "bottom_left",
-    "bottom_right",
-    "top",
-    "bottom",
-    "left",
-    "right",
+    "north_west",
+    "north_east",
+    "south_west",
+    "south_east",
+    "north",
+    "south",
+    "west",
+    "east",
+)
+
+# The four quadrant names above are kept in the historical output order. For
+# ties, use the usual mathematical (counter-clockwise) order starting in the
+# north-east: QI, QII, QIII, QIV.
+TRIGONOMETRIC_QUADRANT_ORDER = (
+    "north_east",
+    "north_west",
+    "south_west",
+    "south_east",
+)
+TRIGONOMETRIC_QUADRANT_INDICES = tuple(
+    REGION_NAMES.index(name) for name in TRIGONOMETRIC_QUADRANT_ORDER
 )
 
 OPTIC_DISC_LABEL = -1
@@ -151,12 +164,16 @@ class TopologicalMetricsPipeline(ArterialSegExample):
             {
                 "dimDesc": ["y", "x"],
                 "coordinate_system": "image_pixel",
+                "image_origin": "lower_left",
+                "y_axis_direction": "increasing_toward_north",
             },
         )
 
         metric_sources: set[str] = set()
         for vessel in vessel_data:
             membership = self._region_membership(
+                vessel.branch_ids,
+                vessel.branch_label_map,
                 vessel.segment_center_xy,
                 optic_disc_center,
             )
@@ -198,13 +215,18 @@ class TopologicalMetricsPipeline(ArterialSegExample):
                     "entries belonging to each region, independently per beat"
                 ),
                 "boundary_policy": (
-                    "x < center_x is left; x >= center_x is right; "
-                    "EyeFlow SegmentCenterXY uses a bottom-up y-axis: "
-                    "y < center_y is bottom; y >= center_y is top"
+                    "x < center_x is west; x >= center_x is east; "
+                    "EyeFlow uses a bottom-up y-axis: y < center_y is south; "
+                    "y >= center_y is north"
                 ),
                 "branch_aggregation": (
-                    "median of per-segment metric values within one EyeFlow "
-                    "branch and region, independently per beat"
+                    "median of all per-segment metric values within an EyeFlow "
+                    "branch assigned to one quadrant by BranchLabelMap area, "
+                    "independently per beat"
+                ),
+                "branch_quadrant_assignment": (
+                    "largest BranchLabelMap pixel area; ties use trigonometric "
+                    "order north-east, north-west, south-west, south-east"
                 ),
                 "branch_group_naming": "branch_<EyeFlow BranchIds value>",
                 "coordinate_order": "x,y",
@@ -315,6 +337,15 @@ class TopologicalMetricsPipeline(ArterialSegExample):
                 f"{name} BranchLabelMap contains labels absent from BranchIds: "
                 f"{unexpected_labels.tolist()}."
             )
+        missing_labels = np.setdiff1d(
+            vessel.branch_ids,
+            np.unique(vessel.branch_label_map),
+        )
+        if missing_labels.size:
+            raise ValueError(
+                f"{name} BranchLabelMap has no pixels for BranchIds: "
+                f"{missing_labels.tolist()}."
+            )
 
         expected_tail = vessel.segment_center_xy.shape[:2]
         for signal_type, waveform in (
@@ -395,26 +426,81 @@ class TopologicalMetricsPipeline(ArterialSegExample):
 
     @staticmethod
     def _region_membership(
+        branch_ids: np.ndarray,
+        branch_label_map: np.ndarray,
         segment_center_xy: np.ndarray,
         optic_disc_center: np.ndarray,
     ) -> np.ndarray:
-        x = segment_center_xy[:, :, 0]
-        y = segment_center_xy[:, :, 1]
-        finite = np.isfinite(x) & np.isfinite(y)
-        left = finite & (x < optic_disc_center[0])
-        right = finite & ~left
-        bottom = finite & (y < optic_disc_center[1])
-        top = finite & ~bottom
+        """Assign every branch and all of its radii to one area-majority region.
+
+        ``BranchLabelMap`` is indexed as ``[y, x]`` while ``SegmentCenterXY``
+        stores coordinates as ``[x, y]``. Both use EyeFlow's bottom-up Y frame,
+        so no transpose, rotation, or vertical flip is applied here.
+        """
+        n_branches, n_radii = segment_center_xy.shape[:2]
+        if branch_ids.size != n_branches:
+            raise ValueError(
+                "BranchIds and SegmentCenterXY must have the same branch count."
+            )
+
+        height, width = branch_label_map.shape
+        pixel_y, pixel_x = np.indices((height, width), dtype=float)
+        west = pixel_x < optic_disc_center[0]
+        east = ~west
+        south = pixel_y < optic_disc_center[1]
+        north = ~south
+        quadrant_masks = np.asarray(
+            (
+                north & west,
+                north & east,
+                south & west,
+                south & east,
+            ),
+            dtype=bool,
+        )
+
+        area_by_quadrant = np.zeros((n_branches, 4), dtype=np.float32)
+        for branch_index, branch_id in enumerate(branch_ids):
+            branch_pixels = branch_label_map == branch_id
+            area_by_quadrant[branch_index] = np.asarray(
+                [np.count_nonzero(branch_pixels & mask) for mask in quadrant_masks],
+                dtype=np.float32,
+            )
+
+        if not np.all(np.any(area_by_quadrant, axis=1)):
+            raise ValueError(
+                "BranchLabelMap must contain at least one pixel for every branch."
+            )
+
+        chosen_quadrants = np.full(n_branches, -1, dtype=np.float32)
+        for branch_index, area in enumerate(area_by_quadrant):
+            if np.any(area):
+                priority_order = np.asarray(TRIGONOMETRIC_QUADRANT_INDICES)
+                chosen_quadrants[branch_index] = priority_order[np.argmax(area[priority_order])]
+
+        assigned_quadrants = np.asarray(
+            [
+                chosen_quadrants == 0,
+                chosen_quadrants == 1,
+                chosen_quadrants == 2,
+                chosen_quadrants == 3,
+            ],
+            dtype=bool,
+        )
+        assigned_quadrants = np.broadcast_to(
+            assigned_quadrants[:, :, np.newaxis],
+            (4, n_branches, n_radii),
+        )
         return np.asarray(
             (
-                top & left,
-                top & right,
-                bottom & left,
-                bottom & right,
-                top,
-                bottom,
-                left,
-                right,
+                assigned_quadrants[0],
+                assigned_quadrants[1],
+                assigned_quadrants[2],
+                assigned_quadrants[3],
+                assigned_quadrants[0] | assigned_quadrants[1],
+                assigned_quadrants[2] | assigned_quadrants[3],
+                assigned_quadrants[0] | assigned_quadrants[2],
+                assigned_quadrants[1] | assigned_quadrants[3],
             ),
             dtype=bool,
         )
@@ -447,9 +533,11 @@ class TopologicalMetricsPipeline(ArterialSegExample):
                 "background_label": 0,
                 "branch_labels": "original EyeFlow BranchIds values",
                 "coordinate_system": "image_pixel",
+                "image_origin": "lower_left",
                 "boundary_policy": (
                     "vertical axis at center_x; horizontal axis at center_y"
                 ),
+                "y_axis_direction": "increasing_toward_north",
                 "description": (
                     "Two-dimensional branch label mask with optic-disc and "
                     "region-axis overlays"

--- a/test/test_topological_metrics.py
+++ b/test/test_topological_metrics.py
@@ -52,7 +52,10 @@ def _write_vessel(
     branch_ids = np.arange(1, n_branches + 1, dtype=np.int32)
     label_map = np.zeros((21, 21), dtype=np.int32)
     for branch_index, branch_id in enumerate(branch_ids):
-        label_map[2 + branch_index : 4 + branch_index, 2:19] = branch_id
+        if branch_index % 2 == 0:
+            label_map[2:6, 2:8] = branch_id
+        else:
+            label_map[15:19, 14:20] = branch_id
 
     raw = np.full(
         (sample_count, n_beats, n_branches, n_radii),
@@ -132,7 +135,7 @@ def _write_topological_input(path: Path, *, source_metrics: bool = False) -> Non
 
 
 class TopologicalMetricsTests(unittest.TestCase):
-    def test_regions_split_each_branch_by_radius_and_aggregate_per_beat(self) -> None:
+    def test_regions_assign_each_branch_by_area_and_aggregate_per_beat(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "input.h5"
             _write_topological_input(path)
@@ -169,16 +172,24 @@ class TopologicalMetricsTests(unittest.TestCase):
             pipeline = TopologicalMetricsPipeline()
             expected = np.asarray(
                 [
-                    pipeline._compute_metrics_1d(raw[:, beat, 1, 1], 1.0)[
-                        "t_max_over_T"
-                    ]
+                    np.nanmedian(
+                        [
+                            pipeline._compute_metrics_1d(
+                                raw[:, beat, 1, radius],
+                                1.0,
+                            )["t_max_over_T"]
+                            for radius in range(raw.shape[3])
+                        ]
+                    )
                     for beat in range(raw.shape[1])
                 ]
             )
-            actual = result.metrics["artery/top_left/global/raw/t_max_over_T"].data
+            actual = result.metrics[
+                "artery/north_east/global/raw/t_max_over_T"
+            ].data
             np.testing.assert_allclose(actual, expected, equal_nan=True)
 
-            branch_prefix = "artery/top_left/by_branch/branch_2"
+            branch_prefix = "artery/north_east/by_branch/branch_2"
             np.testing.assert_allclose(
                 result.metrics[f"{branch_prefix}/raw/t_max_over_T"].data,
                 expected,
@@ -189,11 +200,15 @@ class TopologicalMetricsTests(unittest.TestCase):
                 result.metrics.keys(),
             )
             self.assertIn(
-                "artery/bottom_left/by_branch/branch_1/raw/t_max_over_T",
+                "artery/south_west/by_branch/branch_1/raw/t_max_over_T",
                 result.metrics,
             )
             self.assertNotIn(
-                "artery/top_left/by_branch/branch_1/raw/t_max_over_T",
+                "artery/north_west/by_branch/branch_1/raw/t_max_over_T",
+                result.metrics,
+            )
+            self.assertNotIn(
+                "artery/north_west/by_branch/branch_2/raw/t_max_over_T",
                 result.metrics,
             )
 
@@ -225,19 +240,68 @@ class TopologicalMetricsTests(unittest.TestCase):
             with h5py.File(path, "r") as h5file:
                 result = TopologicalMetricsPipeline().run(h5file)
 
-            region_prefix = "artery/top"
+            region_prefix = "artery/north"
             np.testing.assert_array_equal(
                 result.metrics[f"{region_prefix}/global/raw/PI"].data,
-                [21.0, 21.0],
-            )
-            np.testing.assert_array_equal(
-                result.metrics[f"{region_prefix}/by_branch/branch_1/raw/PI"].data,
-                [11.0, 11.0],
+                [30.5, 30.5],
             )
             np.testing.assert_array_equal(
                 result.metrics[f"{region_prefix}/by_branch/branch_2/raw/PI"].data,
-                [31.0, 31.0],
+                [30.5, 30.5],
             )
+            self.assertNotIn(
+                "artery/north/by_branch/branch_1/raw/PI",
+                result.metrics,
+            )
+
+    def test_equal_quadrant_areas_use_first_trigonometric_quadrant(self) -> None:
+        branch_ids = np.asarray([7], dtype=np.int32)
+        branch_label_map = np.zeros((5, 5), dtype=np.int32)
+        # One pixel in each quadrant around (2, 2), so QI/north-east wins.
+        branch_label_map[3, 1] = 7  # north-west
+        branch_label_map[3, 2] = 7  # north-east
+        branch_label_map[1, 1] = 7  # south-west
+        branch_label_map[1, 2] = 7  # south-east
+        centers = np.asarray([[[1.0, 1.0], [3.0, 3.0]]])
+
+        membership = TopologicalMetricsPipeline._region_membership(
+            branch_ids,
+            branch_label_map,
+            centers,
+            np.asarray([2.0, 2.0]),
+        )
+
+        self.assertTrue(np.all(membership[1]))  # north-east
+        self.assertFalse(np.any(membership[0]))  # north-west
+        self.assertFalse(np.any(membership[2]))  # south-west
+        self.assertFalse(np.any(membership[3]))  # south-east
+        self.assertTrue(np.all(membership[4]))  # north half-plane
+        self.assertTrue(np.all(membership[7]))  # east half-plane
+
+    def test_branch_area_uses_xy_frame_without_transposing_or_flipping(self) -> None:
+        branch_ids = np.asarray([1, 2], dtype=np.int32)
+        branch_label_map = np.zeros((8, 8), dtype=np.int32)
+        branch_label_map[6, 1] = 1  # high y, low x -> north-west
+        branch_label_map[1, 6] = 2  # low y, high x -> south-east
+        centers = np.asarray(
+            [
+                [[7.0, 1.0]],
+                [[1.0, 7.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        membership = TopologicalMetricsPipeline._region_membership(
+            branch_ids,
+            branch_label_map,
+            centers,
+            np.asarray([4.0, 4.0]),
+        )
+
+        self.assertTrue(bool(membership[0, 0, 0]))  # branch 1: north-west
+        self.assertTrue(bool(membership[3, 1, 0]))  # branch 2: south-east
+        self.assertFalse(bool(membership[2, 0, 0]))
+        self.assertFalse(bool(membership[1, 1, 0]))
 
     def test_branch_by_region_hierarchy_is_written_to_h5(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -259,7 +323,7 @@ class TopologicalMetricsTests(unittest.TestCase):
 
             prefix = (
                 "/AngioEye/Processing/topological_metrics/artery/"
-                "top_left/by_branch/branch_2"
+                "north_east/by_branch/branch_2"
             )
             with h5py.File(output_path, "r") as h5file:
                 topology_group = h5file[
@@ -290,7 +354,7 @@ class TopologicalMetricsTests(unittest.TestCase):
                     h5file,
                 )
                 region_group = h5file[
-                    "/AngioEye/Processing/topological_metrics/artery/top_left"
+                    "/AngioEye/Processing/topological_metrics/artery/north_east"
                 ]
                 self.assertEqual(
                     {"by_branch", "global"},
@@ -320,7 +384,7 @@ class TopologicalMetricsTests(unittest.TestCase):
             metric_index = (
                 list(TopologicalMetricsPipeline()._metric_names()).index("PI") + 1
             )
-            actual = result.metrics["vein/top_right/global/raw/PI"].data
+            actual = result.metrics["vein/south_west/global/raw/PI"].data
             np.testing.assert_array_equal(
                 actual,
                 np.full(2, metric_index, dtype=np.float32),
@@ -371,7 +435,7 @@ class TopologicalMetricsTests(unittest.TestCase):
                 result = TopologicalMetricsPipeline().run(h5file)
 
             self.assertTrue(
-                np.all(np.isnan(result.metrics["vein/top/global/raw/PI"].data))
+                np.all(np.isnan(result.metrics["vein/north/global/raw/PI"].data))
             )
 
 


### PR DESCRIPTION
Renamed top, bottom, etc. areas to cardinal names (north, south...). Branches now belong to quadrant they're most present in, no more splitting